### PR TITLE
Fix PDF preview layering and improve AI response formatting

### DIFF
--- a/src/components/AIAssistant.tsx
+++ b/src/components/AIAssistant.tsx
@@ -32,6 +32,9 @@ export const AIAssistant = ({
 
   const aiService = new AIService();
 
+  const formatResponse = (response: string) =>
+    /<[^>]+>/.test(response) ? response : response.replace(/\n/g, '<br>');
+
   const handleAnalyzeProject = async () => {
     if (!clientName.trim() || !projectType.trim()) {
       toast({
@@ -45,7 +48,7 @@ export const AIAssistant = ({
     setIsAnalyzing(true);
     try {
       const analysis = await aiService.analyzeProject(clientName, projectType, selectedModules);
-      onShowSuggestions(analysis);
+      onShowSuggestions(formatResponse(analysis));
       toast({
         title: "Análisis completado",
         description: "El asistente IA ha analizado tu proyecto exitosamente.",
@@ -73,7 +76,7 @@ export const AIAssistant = ({
     setIsOptimizing(true);
     try {
       const optimization = await aiService.optimizePricing(selectedModules, totalAmount);
-      onShowSuggestions(optimization);
+      onShowSuggestions(formatResponse(optimization));
       toast({
         title: "Optimización completada",
         description: "Se han generado recomendaciones de precio.",
@@ -101,7 +104,7 @@ export const AIAssistant = ({
     setIsEvaluatingPayment(true);
     try {
       const evaluation = await aiService.evaluatePaymentGateway(projectType);
-      onShowSuggestions(evaluation);
+      onShowSuggestions(formatResponse(evaluation));
       toast({
         title: "Análisis de pagos completado",
         description: "Se han evaluado las opciones de pasarela de pago.",
@@ -129,7 +132,7 @@ export const AIAssistant = ({
     setIsGeneratingTimeline(true);
     try {
       const timeline = await aiService.generateProjectTimeline(selectedModules);
-      onShowSuggestions(timeline);
+      onShowSuggestions(formatResponse(timeline));
       toast({
         title: "Cronograma generado",
         description: "Se ha creado un timeline detallado del proyecto.",
@@ -178,7 +181,7 @@ export const AIAssistant = ({
       ];
 
       const response = await aiService.callGroqAPI(messages);
-      onShowSuggestions(response);
+      onShowSuggestions(formatResponse(response));
       setCustomPrompt("");
       toast({
         title: "Análisis personalizado completado",
@@ -210,7 +213,7 @@ export const AIAssistant = ({
             placeholder="Escribe una instrucción personalizada para la IA (ej: 'Sugiere módulos adicionales para e-commerce', 'Analiza riesgos del proyecto', etc.)"
             value={customPrompt}
             onChange={(e) => setCustomPrompt(e.target.value)}
-            className="bg-white/20 border-white/30 text-white placeholder:text-white/60 focus:bg-white/30 transition-all duration-200"
+            className="bg-white/90 border-white/30 text-gray-800 placeholder:text-gray-500 focus:bg-white transition-all duration-200"
             rows={3}
           />
           <Button 

--- a/src/components/AISuggestions.tsx
+++ b/src/components/AISuggestions.tsx
@@ -72,7 +72,7 @@ export const AISuggestions = ({ content, isVisible, onClose, onEdit }: AISuggest
             <Textarea
               value={editedContent}
               onChange={(e) => setEditedContent(e.target.value)}
-              className="bg-white/20 border-white/30 text-white placeholder:text-white/60 focus:bg-white/30 transition-all duration-200 min-h-[200px]"
+              className="bg-white text-gray-800 placeholder:text-gray-500 focus:bg-gray-50 transition-all duration-200 min-h-[200px]"
               placeholder="Edita el contenido generado por la IA..."
             />
             <div className="flex gap-2">

--- a/src/components/PDFPreview.tsx
+++ b/src/components/PDFPreview.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { X, Download, Palette, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -56,8 +57,8 @@ export const PDFPreview = ({
     isDarkTheme
   );
 
-  return (
-    <div className="fixed inset-0 bg-black/75 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+  return createPortal(
+    <div className="fixed inset-0 bg-black/75 backdrop-blur-sm z-[1000] flex items-center justify-center p-4">
       <Card className="bg-white rounded-3xl shadow-2xl max-w-4xl w-full max-h-[90vh] overflow-hidden">
         <CardHeader className="flex flex-row items-center justify-between p-6 border-b">
           <CardTitle className="text-2xl font-bold text-gray-800 flex items-center gap-2">
@@ -121,6 +122,7 @@ export const PDFPreview = ({
           </div>
         </CardContent>
       </Card>
-    </div>
+    </div>,
+    document.body
   );
 };


### PR DESCRIPTION
## Summary
- ensure PDF preview portal renders above all content
- format AI responses and unify prompt styling
- improve readability when editing AI suggestions

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9acbce990832896c7732c0a785b7b