### PR TITLE
fix: improve text contrast for accessibility

### DIFF
--- a/src/components/AIAssistant.tsx
+++ b/src/components/AIAssistant.tsx
@@ -219,7 +219,7 @@ export const AIAssistant = ({
           <Button 
             onClick={handleCustomPrompt}
             disabled={isProcessingCustom || !customPrompt.trim()}
-            className="w-full bg-white/20 hover:bg-white/30 text-white font-bold transition-smooth"
+            className="w-full bg-white/20 hover:bg-white/30 text-gray-900 font-bold transition-smooth"
             variant="secondary"
           >
             {isProcessingCustom ? (
@@ -238,7 +238,7 @@ export const AIAssistant = ({
             <Button 
               onClick={handleAnalyzeProject}
               disabled={isAnalyzing}
-              className="bg-white/20 hover:bg-white/30 text-white font-bold transition-smooth text-xs"
+              className="bg-white/20 hover:bg-white/30 text-gray-900 font-bold transition-smooth text-xs"
               variant="secondary"
               size="sm"
             >
@@ -253,7 +253,7 @@ export const AIAssistant = ({
             <Button 
               onClick={handleOptimizePricing}
               disabled={isOptimizing}
-              className="bg-white/20 hover:bg-white/30 text-white font-bold transition-smooth text-xs"
+              className="bg-white/20 hover:bg-white/30 text-gray-900 font-bold transition-smooth text-xs"
               variant="secondary"
               size="sm"
             >
@@ -268,7 +268,7 @@ export const AIAssistant = ({
             <Button 
               onClick={handleEvaluatePaymentGateway}
               disabled={isEvaluatingPayment}
-              className="bg-white/20 hover:bg-white/30 text-white font-bold transition-smooth text-xs"
+              className="bg-white/20 hover:bg-white/30 text-gray-900 font-bold transition-smooth text-xs"
               variant="secondary"
               size="sm"
             >
@@ -283,7 +283,7 @@ export const AIAssistant = ({
             <Button 
               onClick={handleGenerateTimeline}
               disabled={isGeneratingTimeline}
-              className="bg-white/20 hover:bg-white/30 text-white font-bold transition-smooth text-xs"
+              className="bg-white/20 hover:bg-white/30 text-gray-900 font-bold transition-smooth text-xs"
               variant="secondary"
               size="sm"
             >

--- a/src/components/ModuleCard.tsx
+++ b/src/components/ModuleCard.tsx
@@ -71,7 +71,7 @@ export const ModuleCard = ({
         
         {/* Description */}
         <div className="mb-6">
-          <p className="text-sm text-gray-600 leading-relaxed break-words line-clamp-3">
+          <p className="text-sm text-gray-800 leading-relaxed break-words line-clamp-3">
             {module.description}
           </p>
         </div>

--- a/src/components/PDFPreview.tsx
+++ b/src/components/PDFPreview.tsx
@@ -67,7 +67,7 @@ export const PDFPreview = ({
           </CardTitle>
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-2">
-              <Palette className="w-4 h-4 text-gray-600" />
+              <Palette className="w-4 h-4 text-gray-800" />
               <Label htmlFor="theme-switch" className="text-sm font-medium">
                 Tema Oscuro
               </Label>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -15,7 +15,7 @@ const NotFound = () => {
     <div className="min-h-screen flex items-center justify-center bg-gray-100">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
+        <p className="text-xl text-gray-800 mb-4">Oops! Page not found</p>
         <a href="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
         </a>


### PR DESCRIPTION
## Summary
- swap white text for darker gray in AI assistant buttons to increase contrast
- darken placeholder text in NotFound and module cards for better legibility
- adjust PDF preview palette icon to a darker tone for clarity

## Testing
- ⚠️ `npm test` (missing script: "test")
- ⚠️ `npm run lint` (reported existing lint errors in unrelated files)
- ✅ `npx eslint src/components/AIAssistant.tsx src/pages/NotFound.tsx src/components/PDFPreview.tsx src/components/ModuleCard.tsx`
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9dc707b74832894ea0c5ffd0be319