### PR TITLE
feat: refresh color palette with modern glass design

### DIFF
--- a/src/components/ClientForm.tsx
+++ b/src/components/ClientForm.tsx
@@ -27,7 +27,7 @@ export const ClientForm = ({
           placeholder="Nombre del cliente..."
           value={clientName}
           onChange={(e) => onClientNameChange(e.target.value)}
-          className="bg-white/90 border-webnova-300 focus:ring-webnova-500 focus:border-transparent transition-smooth text-gray-800 font-medium"
+          className="bg-white/10 border-white/20 text-white placeholder-gray-400 focus:ring-webnova-500 focus:border-transparent transition-smooth font-medium"
         />
       </div>
       <div className="space-y-2">
@@ -40,7 +40,7 @@ export const ClientForm = ({
           placeholder="Ej: Sitio de reservas..."
           value={projectType}
           onChange={(e) => onProjectTypeChange(e.target.value)}
-          className="bg-white/90 border-webnova-300 focus:ring-webnova-500 focus:border-transparent transition-smooth text-gray-800 font-medium"
+          className="bg-white/10 border-white/20 text-white placeholder-gray-400 focus:ring-webnova-500 focus:border-transparent transition-smooth font-medium"
         />
       </div>
     </div>

--- a/src/components/ModuleCard.tsx
+++ b/src/components/ModuleCard.tsx
@@ -28,8 +28,8 @@ export const ModuleCard = ({
   };
 
   return (
-    <Card 
-      className="group relative bg-gradient-to-br from-white via-gray-50 to-gray-100 hover:from-webnova-50 hover:via-white hover:to-webnova-50 transition-all duration-300 shadow-lg hover:shadow-elegant border border-gray-200 hover:border-webnova-300 transform hover:-translate-y-2"
+    <Card
+      className="group relative bg-white/5 backdrop-blur-lg border border-white/10 hover:border-webnova-400/50 transition-all duration-300 shadow-card hover:shadow-glow transform hover:-translate-y-2"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
@@ -37,14 +37,14 @@ export const ModuleCard = ({
         {/* Module Header */}
         <div className="flex justify-between items-start mb-4">
           <div className="flex-1 pr-4">
-            <h3 className="text-lg font-bold text-gray-800 group-hover:text-webnova-700 transition-colors duration-200 leading-tight mb-2 break-words">
+            <h3 className="text-lg font-bold text-white group-hover:text-webnova-200 transition-colors duration-200 leading-tight mb-2 break-words">
               {module.name}
             </h3>
-            <p className="text-2xl font-black text-webnova-600">
+            <p className="text-2xl font-black text-webnova-300">
               RD$ {module.price.toLocaleString()}
             </p>
             {module.category && (
-              <span className="inline-block mt-2 px-2 py-1 bg-webnova-100 text-webnova-700 text-xs font-semibold rounded-full">
+              <span className="inline-block mt-2 px-2 py-1 bg-webnova-500/20 text-webnova-100 text-xs font-semibold rounded-full">
                 {module.category}
               </span>
             )}
@@ -55,7 +55,7 @@ export const ModuleCard = ({
             <Button
               onClick={() => onEdit(module)}
               size="sm"
-              className="p-2 bg-blue-500 hover:bg-blue-600 text-white rounded-full shadow-md transform hover:scale-110 transition-bounce"
+              className="p-2 bg-webnova-500 hover:bg-webnova-600 text-white rounded-full shadow-md transform hover:scale-110 transition-bounce"
             >
               <Edit className="w-3 h-3" />
             </Button>
@@ -68,10 +68,10 @@ export const ModuleCard = ({
             </Button>
           </div>
         </div>
-        
+
         {/* Description */}
         <div className="mb-6">
-          <p className="text-sm text-gray-800 leading-relaxed break-words line-clamp-3">
+          <p className="text-sm text-gray-200 leading-relaxed break-words line-clamp-3">
             {module.description}
           </p>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -7,54 +7,54 @@
 @layer base {
   :root {
     /* WebNova Brand Colors */
-    --webnova-50: 240 253 250;
-    --webnova-100: 204 251 241;
-    --webnova-200: 153 246 228;
-    --webnova-300: 94 234 212;
-    --webnova-400: 45 212 191;
-    --webnova-500: 20 184 166;
-    --webnova-600: 13 148 136;
-    --webnova-700: 15 118 110;
-    --webnova-800: 17 94 89;
-    --webnova-900: 19 78 74;
+    --webnova-50: 250 100% 98%;
+    --webnova-100: 251 91% 95%;
+    --webnova-200: 251 95% 92%;
+    --webnova-300: 252 95% 85%;
+    --webnova-400: 255 92% 76%;
+    --webnova-500: 258 90% 66%;
+    --webnova-600: 262 83% 58%;
+    --webnova-700: 263 70% 50%;
+    --webnova-800: 263 69% 42%;
+    --webnova-900: 264 67% 35%;
 
     /* Base Theme */
-    --background: 222 84% 5%;
+    --background: 250 35% 6%;
     --foreground: 210 40% 98%;
 
-    --card: 222 84% 5%;
+    --card: 250 35% 6%;
     --card-foreground: 210 40% 98%;
 
-    --popover: 222 84% 5%;
+    --popover: 250 35% 6%;
     --popover-foreground: 210 40% 98%;
 
-    --primary: 20 184 166;
+    --primary: 258 90% 66%;
     --primary-foreground: 210 40% 98%;
 
-    --secondary: 240 3.7% 15.9%;
+    --secondary: 263 70% 14%;
     --secondary-foreground: 210 40% 98%;
 
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
+    --muted: 263 70% 14%;
+    --muted-foreground: 260 10% 60%;
 
-    --accent: 240 3.7% 15.9%;
+    --accent: 263 70% 14%;
     --accent-foreground: 210 40% 98%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 20 184 166;
+    --border: 263 70% 14%;
+    --input: 263 70% 14%;
+    --ring: 258 90% 66%;
 
     --radius: 0.75rem;
 
     /* Professional Gradients */
     --gradient-primary: linear-gradient(135deg, hsl(var(--webnova-500)), hsl(var(--webnova-600)));
     --gradient-secondary: linear-gradient(135deg, hsl(var(--webnova-600)), hsl(var(--webnova-700)));
-    --gradient-hero: linear-gradient(135deg, hsl(222 84% 5%) 0%, hsl(240 3.7% 15.9%) 50%, hsl(var(--webnova-900)) 100%);
-    --gradient-card: linear-gradient(145deg, hsl(240 3.7% 15.9% / 0.8), hsl(240 3.7% 20% / 0.9));
-    --gradient-ai: linear-gradient(-45deg, hsl(265 85% 62%), hsl(338 76% 65%), hsl(205 79% 60%), hsl(var(--webnova-400)));
+    --gradient-hero: linear-gradient(135deg, hsl(250 35% 6%) 0%, hsl(263 70% 14%) 50%, hsl(var(--webnova-900)) 100%);
+    --gradient-card: linear-gradient(145deg, hsl(263 70% 14% / 0.8), hsl(263 70% 18% / 0.9));
+    --gradient-ai: linear-gradient(-45deg, hsl(291 76% 65%), hsl(338 90% 62%), hsl(189 90% 60%), hsl(var(--webnova-400)));
 
     /* Shadows */
     --shadow-elegant: 0 25px 50px -12px hsl(0 0% 0% / 0.25);
@@ -141,7 +141,7 @@
   }
   
   .ai-thinking {
-    background: linear-gradient(-45deg, hsl(265 85% 62%), hsl(338 76% 65%), hsl(205 79% 60%), hsl(var(--webnova-400)));
+    background: linear-gradient(-45deg, hsl(291 76% 65%), hsl(338 90% 62%), hsl(189 90% 60%), hsl(var(--webnova-400)));
     background-size: 400% 400%;
     animation: ai-thinking 2s ease infinite;
   }

--- a/src/pages/QuotationApp.tsx
+++ b/src/pages/QuotationApp.tsx
@@ -122,9 +122,9 @@ export default function QuotationApp() {
   };
 
   return (
-    <div className="bg-gradient-to-br from-gray-900 via-gray-800 to-webnova-900 min-h-screen font-inter">
+    <div className="bg-gradient-to-br from-gray-950 via-webnova-900 to-black min-h-screen font-inter">
       {/* Header */}
-      <div className="relative overflow-hidden bg-gradient-to-r from-webnova-600 via-webnova-500 to-webnova-400">
+      <div className="relative overflow-hidden bg-gradient-to-r from-webnova-700 via-webnova-600 to-webnova-500">
         <div className="absolute inset-0 bg-black opacity-20"></div>
         <div className="relative container mx-auto px-6 py-16 text-center">
           <div className="animate-float mb-8">


### PR DESCRIPTION
## Summary
- migrate brand palette to vibrant violet shades with updated gradients
- introduce glassmorphic module cards with updated controls
- modernize client form inputs and layout background

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: An interface declaring no members is equivalent to its supertype, A `require()` style import is forbidden)
- `npx eslint src/components/ClientForm.tsx src/components/ModuleCard.tsx src/pages/QuotationApp.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9e480773c832898353df9aafaafdc