### PR TITLE
Handle localStorage errors to stabilize module selection

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/QuotationApp.tsx
+++ b/src/pages/QuotationApp.tsx
@@ -33,30 +33,38 @@ export default function QuotationApp() {
 
   // Local storage persistence
   useEffect(() => {
-    const saved = localStorage.getItem('webnova-quotation');
-    if (saved) {
-      try {
+    try {
+      const saved = typeof window !== 'undefined'
+        ? localStorage.getItem('webnova-quotation')
+        : null;
+      if (saved) {
         const data = JSON.parse(saved);
         setClientName(data.clientName || "");
         setProjectType(data.projectType || "");
         setModules(data.modules || DEFAULT_MODULES);
         setSelectedModuleIds(data.selectedModuleIds || []);
         setNextId(data.nextId || 15);
-      } catch (error) {
-        console.error('Error loading saved data:', error);
       }
+    } catch (error) {
+      console.error('Error loading saved data:', error);
     }
   }, []);
 
   useEffect(() => {
-    const data = {
-      clientName,
-      projectType,
-      modules,
-      selectedModuleIds,
-      nextId
-    };
-    localStorage.setItem('webnova-quotation', JSON.stringify(data));
+    if (typeof window !== 'undefined') {
+      try {
+        const data = {
+          clientName,
+          projectType,
+          modules,
+          selectedModuleIds,
+          nextId
+        };
+        localStorage.setItem('webnova-quotation', JSON.stringify(data));
+      } catch (error) {
+        console.error('Error saving data:', error);
+      }
+    }
   }, [clientName, projectType, modules, selectedModuleIds, nextId]);
 
   // Event handlers

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -141,5 +142,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Safely load and save quotation data to localStorage
- Clean up empty interfaces and switch tailwind plugin to ESM import

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9ea1ccf688328b7ec9857e8b2dbb0