### PR TITLE
fix: preserve line breaks in pdf

### DIFF
--- a/src/components/FloatingAIAssistant.tsx
+++ b/src/components/FloatingAIAssistant.tsx
@@ -16,7 +16,7 @@ interface FloatingAIAssistantProps {
   projectType: string;
 }
 
-export const FloatingAIAssistant = ({ 
+export const FloatingAIAssistant = ({
   modules, 
   selectedModules, 
   onAddModule,
@@ -26,7 +26,8 @@ export const FloatingAIAssistant = ({
   const [isOpen, setIsOpen] = useState(false);
   const [prompt, setPrompt] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [suggestions, setSuggestions] = useState<any[]>([]);
+  type SuggestedModule = Omit<Module, 'id'>;
+  const [suggestions, setSuggestions] = useState<SuggestedModule[]>([]);
   const [lastResponse, setLastResponse] = useState("");
 
   const aiService = new AIService();
@@ -88,7 +89,7 @@ export const FloatingAIAssistant = ({
     tempDiv.innerHTML = response;
     const moduleButtons = tempDiv.querySelectorAll('.add-module-btn');
     
-    const newSuggestions: any[] = [];
+    const newSuggestions: SuggestedModule[] = [];
     moduleButtons.forEach(btn => {
       const name = btn.getAttribute('data-name');
       const price = btn.getAttribute('data-price');
@@ -106,7 +107,7 @@ export const FloatingAIAssistant = ({
     setSuggestions(newSuggestions);
   };
 
-  const handleAddSuggestedModule = (module: any) => {
+  const handleAddSuggestedModule = (module: SuggestedModule) => {
     onAddModule({
       name: module.name,
       price: module.price,

--- a/src/services/pdfService.ts
+++ b/src/services/pdfService.ts
@@ -102,14 +102,22 @@ export class PDFService {
 
     const companyEmail = customContent?.companyEmail || "info.webnovalab@gmail.com";
     const companyPhone = customContent?.companyPhone || "+1 (809) 123-4567";
-    const finalNotes = customContent?.notes || "Gracias por la oportunidad de cotizar para su proyecto. ¡Esperamos trabajar con ustedes!";
-    const terms = customContent?.terms || [
+
+    // Preserve user line breaks by converting newlines to <br> tags
+    const formatMultilineText = (text: string) =>
+      text.replace(/\n/g, '<br/>');
+
+    const finalNotes = customContent?.notes
+      ? formatMultilineText(customContent.notes)
+      : "Gracias por la oportunidad de cotizar para su proyecto. ¡Esperamos trabajar con ustedes!";
+
+    const terms = (customContent?.terms || [
       "El proyecto incluye 2 rondas de revisiones sin costo adicional",
       "Cambios mayores fuera del alcance original se cotizarán por separado",
       "El cliente debe proporcionar contenido y materiales dentro de 5 días hábiles",
       "Garantía de 3 meses en funcionalidades desarrolladas",
       "Soporte técnico gratuito por 30 días post-entrega"
-    ];
+    ]).map(term => formatMultilineText(term));
 
     return `
       <div style="font-family: 'Inter', Arial, sans-serif; margin: 0; padding: 40px; background: ${bgColor}; color: ${textColor}; line-height: 1.6;">


### PR DESCRIPTION
## Summary
- preserve user line breaks in notes and terms when generating PDFs
- tighten types for AI assistant suggestions to satisfy lint rules

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb52e8ac4c8328b58451090f2808b6