### PR TITLE
feat: add direct pdf download

### DIFF
--- a/src/components/ControlButtons.tsx
+++ b/src/components/ControlButtons.tsx
@@ -54,6 +54,47 @@ export const ControlButtons = ({
     setShowPDFPreview(true);
   };
 
+  const handleDownloadPDF = async () => {
+    if (!clientName.trim()) {
+      toast({
+        title: "Cliente requerido",
+        description: "Por favor, ingresa el nombre del cliente antes de generar el PDF.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (selectedModules.length === 0) {
+      toast({
+        title: "Sin módulos seleccionados",
+        description: "Por favor, selecciona al menos un módulo para generar la cotización.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      await pdfService.generateProfessionalPDF(
+        clientName,
+        projectType,
+        selectedModules,
+        totalAmount,
+        usdRate
+      );
+      toast({
+        title: "PDF generado",
+        description: "La cotización se ha descargado correctamente.",
+      });
+    } catch (error) {
+      console.error('Error generating PDF:', error);
+      toast({
+        title: "Error al generar PDF",
+        description: "No se pudo descargar el PDF.",
+        variant: "destructive",
+      });
+    }
+  };
+
   const handleExportData = () => {
     const data: QuotationData = {
       client: clientName,
@@ -135,7 +176,15 @@ export const ControlButtons = ({
           <Eye className="w-4 h-4" />
           Vista Previa PDF
         </Button>
-        
+
+        <Button
+          onClick={handleDownloadPDF}
+          className="bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 text-white font-bold shadow-lg transform hover:scale-105 transition-bounce flex items-center gap-2"
+        >
+          <FileText className="w-4 h-4" />
+          Descargar PDF
+        </Button>
+
         <Button
           onClick={handleExportData}
           className="bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white font-bold shadow-lg transform hover:scale-105 transition-bounce flex items-center gap-2"

--- a/src/components/FloatingAIAssistant.tsx
+++ b/src/components/FloatingAIAssistant.tsx
@@ -16,7 +16,7 @@ interface FloatingAIAssistantProps {
   projectType: string;
 }
 
-export const FloatingAIAssistant = ({ 
+export const FloatingAIAssistant = ({
   modules, 
   selectedModules, 
   onAddModule,
@@ -26,7 +26,8 @@ export const FloatingAIAssistant = ({
   const [isOpen, setIsOpen] = useState(false);
   const [prompt, setPrompt] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [suggestions, setSuggestions] = useState<any[]>([]);
+  type SuggestedModule = Omit<Module, 'id'>;
+  const [suggestions, setSuggestions] = useState<SuggestedModule[]>([]);
   const [lastResponse, setLastResponse] = useState("");
 
   const aiService = new AIService();
@@ -88,7 +89,7 @@ export const FloatingAIAssistant = ({
     tempDiv.innerHTML = response;
     const moduleButtons = tempDiv.querySelectorAll('.add-module-btn');
     
-    const newSuggestions: any[] = [];
+    const newSuggestions: SuggestedModule[] = [];
     moduleButtons.forEach(btn => {
       const name = btn.getAttribute('data-name');
       const price = btn.getAttribute('data-price');
@@ -106,7 +107,7 @@ export const FloatingAIAssistant = ({
     setSuggestions(newSuggestions);
   };
 
-  const handleAddSuggestedModule = (module: any) => {
+  const handleAddSuggestedModule = (module: SuggestedModule) => {
     onAddModule({
       name: module.name,
       price: module.price,

--- a/src/components/PDFPreview.tsx
+++ b/src/components/PDFPreview.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useToast } from "@/hooks/use-toast";
 import { createPortal } from "react-dom";
 import { X, Download, Palette, FileText, Edit3, Save } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -32,6 +33,7 @@ export const PDFPreview = ({
   const [isDarkTheme, setIsDarkTheme] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
+  const { toast } = useToast();
   const [editableContent, setEditableContent] = useState({
     clientName,
     projectType,
@@ -68,8 +70,18 @@ export const PDFPreview = ({
           terms: editableContent.terms
         }
       );
+      toast({
+        title: "PDF generado",
+        description: "La cotización se ha descargado correctamente.",
+      });
+      onClose();
     } catch (error) {
       console.error('Error generating PDF:', error);
+      toast({
+        title: "Error al generar PDF",
+        description: "No se pudo descargar el PDF.",
+        variant: "destructive",
+      });
     } finally {
       setIsGenerating(false);
     }

--- a/src/services/pdfService.ts
+++ b/src/services/pdfService.ts
@@ -102,14 +102,22 @@ export class PDFService {
 
     const companyEmail = customContent?.companyEmail || "info.webnovalab@gmail.com";
     const companyPhone = customContent?.companyPhone || "+1 (809) 123-4567";
-    const finalNotes = customContent?.notes || "Gracias por la oportunidad de cotizar para su proyecto. ¡Esperamos trabajar con ustedes!";
-    const terms = customContent?.terms || [
+
+    // Preserve user line breaks by converting newlines to <br> tags
+    const formatMultilineText = (text: string) =>
+      text.replace(/\n/g, '<br/>');
+
+    const finalNotes = customContent?.notes
+      ? formatMultilineText(customContent.notes)
+      : "Gracias por la oportunidad de cotizar para su proyecto. ¡Esperamos trabajar con ustedes!";
+
+    const terms = (customContent?.terms || [
       "El proyecto incluye 2 rondas de revisiones sin costo adicional",
       "Cambios mayores fuera del alcance original se cotizarán por separado",
       "El cliente debe proporcionar contenido y materiales dentro de 5 días hábiles",
       "Garantía de 3 meses en funcionalidades desarrolladas",
       "Soporte técnico gratuito por 30 días post-entrega"
-    ];
+    ]).map(term => formatMultilineText(term));
 
     return `
       <div style="font-family: 'Inter', Arial, sans-serif; margin: 0; padding: 40px; background: ${bgColor}; color: ${textColor}; line-height: 1.6;">


### PR DESCRIPTION
## Summary
- allow direct PDF download with validation and success/error toasts
- close preview automatically after generating PDF to avoid lingering overlay

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb52e8ac4c8328b58451090f2808b6